### PR TITLE
Fix deprications

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for avahi_aliases
 APT_CACHE_VALID_TIME: 3600
+AVAHI_ALIASES_CONFIG_DIR: /etc/avahi/aliases.d

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -116,9 +116,4 @@ galaxy_info:
   #- packaging
   #- system
   #- web
-dependencies:
-  - ajsalminen.avahi_common
-  # List your role dependencies here, one per line. Only
-  # dependencies available via galaxy should be listed here.
-  # Be sure to remove the '[]' above if you add dependencies
-  # to this list.
+dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,24 +3,20 @@
 
 - name: Install avahi and other requirements.
   apt:
-    pkg={{item}}
-    state=present
-    update_cache=yes
-    cache_valid_time={{APT_CACHE_VALID_TIME}}
-  with_items:
-    - python-avahi
-    - python-pip
-    - avahi-daemon
-    - git
-    - libnss-mdns
-    - python-daemon
+    name:
+      - python-avahi
+      - python-pip
+      - avahi-daemon
+      - git
+      - libnss-mdns
+      - python-daemon
+    state: present
+    update_cache: yes
+    cache_valid_time: "{{APT_CACHE_VALID_TIME}}"
 
-
-# Need to run manually until https://github.com/ansible/ansible-modules-core/pull/227
 - name: Install avahi-aliases
-  command: /usr/bin/pip install git+https://github.com/airtonix/avahi-aliases.git
-
-
+  pip:
+    name: git+https://github.com/airtonix/avahi-aliases.git
 
 - name: Create aliases directory.
   file:

--- a/templates/avahi_aliases.j2
+++ b/templates/avahi_aliases.j2
@@ -1,3 +1,0 @@
-{% for alias in avahi_aliases_aliases %}
-{{alias}}.local
-{% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for avahi_aliases


### PR DESCRIPTION
- Use pip module to install avahi-alias and fix apt deprication warning.

> [DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is 
deprecated. Instead of using a loop to supply multiple items and specifying `name: {{ item }}`, 
please use `name: u'{{ git_packages }}'` and remove the loop. This feature will be removed in 
version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.

- Remove avahi_common dependency, and move AVAHI_ALIASES_CONFIG_DIR to this role.