### PR TITLE
Add Python 3 support for newer distros

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,19 +4,20 @@
 - name: Install avahi and other requirements.
   apt:
     name:
-      - python-avahi
-      - python-pip
+      - python3-avahi
+      - python3-pip
       - avahi-daemon
       - git
       - libnss-mdns
-      - python-daemon
+      - python3-daemon
     state: present
     update_cache: yes
     cache_valid_time: "{{APT_CACHE_VALID_TIME}}"
 
-- name: Install avahi-aliases
+- name: Install avahi-aliases.
   pip:
     name: git+https://github.com/airtonix/avahi-aliases.git
+    extra_args: --break-system-packages
 
 - name: Create aliases directory.
   file:


### PR DESCRIPTION
Newer distributions use Python 3 by default and have renamed some specific Python packages.

WIP, because of the high reliance of other playbooks on this role. I haven't thoroughly tested this with most of the other playbooks, however I have not yet encountered any issues with ansible I am running (ansible 2.10.17).