### PR TITLE
Fix avahi deps for debian 10 and less

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for avahi_aliases
 
-- name: Install avahi and aliases.
+- name: Install avahi and avahi-aliases for Debian Bullseye and later.
   block:
   - name: Install avahi and other requirements.
     apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
 
   when: ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 11
 
-- name: Install avahi and aliases.
+- name: Install avahi and avahi-aliases for Debian Buster and earlier.
   block:
   - name: Install avahi and other requirements.
     apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,48 @@
 ---
 # tasks file for avahi_aliases
 
-- name: Install avahi and other requirements.
-  apt:
-    name:
-      - python3-avahi
-      - python3-pip
-      - avahi-daemon
-      - git
-      - libnss-mdns
-      - python3-daemon
-    state: present
-    update_cache: yes
-    cache_valid_time: "{{APT_CACHE_VALID_TIME}}"
+- name: Install avahi and aliases.
+  block:
+  - name: Install avahi and other requirements.
+    apt:
+      name:
+        - python3-avahi
+        - python3-pip
+        - avahi-daemon
+        - git
+        - libnss-mdns
+        - python3-daemon
+      state: present
+      update_cache: yes
+      cache_valid_time: "{{APT_CACHE_VALID_TIME}}"
 
-- name: Install avahi-aliases.
-  pip:
-    name: git+https://github.com/airtonix/avahi-aliases.git
-    extra_args: --break-system-packages
+  - name: Install avahi-aliases.
+    pip:
+      name: git+https://github.com/airtonix/avahi-aliases.git
+      extra_args: --break-system-packages
+
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 11
+
+- name: Install avahi and aliases.
+  block:
+  - name: Install avahi and other requirements.
+    apt:
+      name:
+        - python-avahi
+        - python-pip
+        - avahi-daemon
+        - git
+        - libnss-mdns
+        - python-daemon
+      state: present
+      update_cache: yes
+      cache_valid_time: "{{APT_CACHE_VALID_TIME}}"
+
+  - name: Install avahi-aliases.
+    pip:
+      name: git+https://github.com/airtonix/avahi-aliases.git
+
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version|int < 11
 
 - name: Create aliases directory.
   file:


### PR DESCRIPTION
python3-avahi doesnt exist in pre bullseye package archives. use python-avahi for older versions